### PR TITLE
fix: corrected transparency behavior

### DIFF
--- a/frontend/src/canvas/types/arrow/arrow.ts
+++ b/frontend/src/canvas/types/arrow/arrow.ts
@@ -85,9 +85,9 @@ export class ArrowShape extends BaseShape {
         headSize: number = 30,
         thickness: number = 15,
         rotation: number = 0,
-        fill: string = 'transparent',
-        fillOpacity: number = 1,
-        stroke: string = '#000000',
+        fill: string = '#3498db',
+        fillOpacity: number = 0,
+        stroke: string = '#2c3e50',
         strokeOpacity: number = 1,
         strokeWidth: number = 2
     ) {

--- a/frontend/src/canvas/types/hexagon/hexagon.ts
+++ b/frontend/src/canvas/types/hexagon/hexagon.ts
@@ -72,9 +72,9 @@ export class HexagonShape extends BaseShape {
         width: number = 100,
         height: number = 100,
         rotation: number = 0,
-        fill: string = 'transparent',
-        fillOpacity: number = 1,
-        stroke: string = '#000000',
+        fill: string = '#3498db',
+        fillOpacity: number = 0,
+        stroke: string = '#2c3e50',
         strokeOpacity: number = 1,
         strokeWidth: number = 2
     ) {

--- a/frontend/src/canvas/types/polygon/polygon.ts
+++ b/frontend/src/canvas/types/polygon/polygon.ts
@@ -82,9 +82,9 @@ export class PolygonShape extends BaseShape {
         width: number = 100,
         height: number = 100,
         rotation: number = 0,
-        fill: string = 'transparent',
-        fillOpacity: number = 1,
-        stroke: string = '#000000',
+        fill: string = '#3498db',
+        fillOpacity: number = 0,
+        stroke: string = '#2c3e50',
         strokeOpacity: number = 1,
         strokeWidth: number = 2
     ) {

--- a/frontend/src/canvas/types/star/star.ts
+++ b/frontend/src/canvas/types/star/star.ts
@@ -84,9 +84,9 @@ export class StarShape extends BaseShape {
         width: number = 120,
         height: number = 120,
         rotation: number = 0,
-        fill: string = 'transparent',
-        fillOpacity: number = 1,
-        stroke: string = '#000000',
+        fill: string = '#3498db',
+        fillOpacity: number = 0,
+        stroke: string = '#2c3e50',
         strokeOpacity: number = 1,
         strokeWidth: number = 2
     ) {

--- a/frontend/src/canvas/types/triangle/triangle.ts
+++ b/frontend/src/canvas/types/triangle/triangle.ts
@@ -72,9 +72,9 @@ export class TriangleShape extends BaseShape {
         width: number = 80,
         height: number = 80,
         rotation: number = 0,
-        fill: string = 'transparent',
-        fillOpacity: number = 1,
-        stroke: string = '#000000',
+        fill: string = '#3498db',
+        fillOpacity: number = 0,
+        stroke: string = '#2c3e50',
         strokeOpacity: number = 1,
         strokeWidth: number = 2
     ) {

--- a/frontend/src/stores/canvas.ts
+++ b/frontend/src/stores/canvas.ts
@@ -189,9 +189,9 @@ export const useCanvasStore = defineStore('canvas', () => {
                 100,
                 100,
                 0,
-                'transparent',
-                1,
-                '#000000',
+                '#3498db',
+                0,
+                '#2c3e50',
                 1,
                 2
             );


### PR DESCRIPTION
Closed https://github.com/fami-2026/vector-graphic-editor/issues/89
Исправлено поведение непрозрачности заливки при создании треугольника, многоугольника, звезды и стрелки.