### PR TITLE
fix: default filling

### DIFF
--- a/frontend/src/gui/components/InspectorPanel.vue
+++ b/frontend/src/gui/components/InspectorPanel.vue
@@ -668,7 +668,7 @@ function thumbFillOpacity(shape: Shape): number {
 
     const opacity = (shape as unknown as Record<string, unknown>)
         .fillOpacity as number | undefined;
-    return typeof opacity === 'number' ? Math.max(0, Math.min(1,opacity)) : 1;
+    return typeof opacity === 'number' ? Math.max(0, Math.min(1, opacity)) : 1;
 }
 
 function thumbStroke(shape: Shape): string {


### PR DESCRIPTION
Closed#96: thumbnails have a transparent fill when initializing shapes