### PR TITLE
fix: reset selection frame when switching tools

### DIFF
--- a/frontend/src/canvas/composables/useInteractions.ts
+++ b/frontend/src/canvas/composables/useInteractions.ts
@@ -50,12 +50,15 @@ export function useInteractions(
     const createToolType = ref<ToolType | null>(null);
     const createParams = ref<Record<string, unknown> | null>(null);
 
-    watch(() => toolsStore.activeTool, (newTool) => {
-        if (newTool !== 'select') {
-            canvasStore.selectShape(null);
-            activeShape.value = null;
+    watch(
+        () => toolsStore.activeTool,
+        (newTool) => {
+            if (newTool !== 'select') {
+                canvasStore.selectShape(null);
+                activeShape.value = null;
+            }
         }
-    });
+    );
 
     // Синхронизация выделенной фигуры из стора
     watch(


### PR DESCRIPTION
Closed #139 
Рамка выделения сбрасывается при переключении с инструмента "Курсор" на к.-л. другой