### PR TITLE
Fix/139 frame select

### DIFF
--- a/frontend/src/canvas/composables/useInteractions.ts
+++ b/frontend/src/canvas/composables/useInteractions.ts
@@ -50,12 +50,15 @@ export function useInteractions(
     const createToolType = ref<ToolType | null>(null);
     const createParams = ref<Record<string, unknown> | null>(null);
 
-    watch(() => toolsStore.activeTool, (newTool) => {
-        if (newTool !== 'select') {
-            canvasStore.selectShape(null);
-            activeShape.value = null;
+    watch(
+        () => toolsStore.activeTool,
+        (newTool) => {
+            if (newTool !== 'select') {
+                canvasStore.selectShape(null);
+                activeShape.value = null;
+            }
         }
-    });
+    );
 
     // Синхронизация выделенной фигуры из стора
     watch(
@@ -120,13 +123,14 @@ export function useInteractions(
         const worldX = getLocalPoint(e).x;
         const worldY = getLocalPoint(e).y;
 
-        const delta = e.deltaY > 0 ? -canvasStore.ZOOM_STEP : canvasStore.ZOOM_STEP;
+        const delta =
+            e.deltaY > 0 ? -canvasStore.ZOOM_STEP : canvasStore.ZOOM_STEP;
         const newZoom = Math.max(
-            canvasStore.MIN_ZOOM, 
+            canvasStore.MIN_ZOOM,
             Math.min(canvasStore.MAX_ZOOM, oldZoom + delta)
         );
         const newZoomFactor = newZoom / 100;
-        
+
         const newPanX = screenX - centerX - (worldX - centerX) * newZoomFactor;
         const newPanY = screenY - centerY - (worldY - centerY) * newZoomFactor;
 

--- a/frontend/src/canvas/utils/export.ts
+++ b/frontend/src/canvas/utils/export.ts
@@ -169,15 +169,15 @@ function getTotalBounds(shapes: Shape[]): ExportBounds {
         return { x: 0, y: 0, width: 1, height: 1 };
     }
 
-    const bounds = shapes.map(shape => shape.getBoundingBox());
-    
-    const minX = Math.min(...bounds.map(b => b.minX));
-    const minY = Math.min(...bounds.map(b => b.minY));
-    const maxX = Math.max(...bounds.map(b => b.maxX));
-    const maxY = Math.max(...bounds.map(b => b.maxY));
-    
+    const bounds = shapes.map((shape) => shape.getBoundingBox());
+
+    const minX = Math.min(...bounds.map((b) => b.minX));
+    const minY = Math.min(...bounds.map((b) => b.minY));
+    const maxX = Math.max(...bounds.map((b) => b.maxX));
+    const maxY = Math.max(...bounds.map((b) => b.maxY));
+
     const width = Math.max(1, maxX - minX);
     const height = Math.max(1, maxY - minY);
-    
+
     return { x: minX, y: minY, width, height };
 }

--- a/frontend/src/gui/components/BottomLeftControls.vue
+++ b/frontend/src/gui/components/BottomLeftControls.vue
@@ -183,7 +183,7 @@ function cancelEditing() {
     font-size: 12px;
     font-weight: 600;
     color: #374151;
-    border: 1px solid #2196F3;
+    border: 1px solid #2196f3;
     border-radius: 4px;
     padding: 2px 4px;
     outline: none;

--- a/frontend/src/gui/components/ExportDropdown.vue
+++ b/frontend/src/gui/components/ExportDropdown.vue
@@ -21,7 +21,12 @@
         </button>
 
         <div v-if="open" class="menu" role="menu">
-            <button class="item" role="menuitem" type="button" @click="openExport('png')">
+            <button
+                class="item"
+                role="menuitem"
+                type="button"
+                @click="openExport('png')"
+            >
                 PNG
             </button>
             <button

--- a/frontend/src/gui/components/InspectorPanel.vue
+++ b/frontend/src/gui/components/InspectorPanel.vue
@@ -489,12 +489,12 @@ function handleClickOutside(event: MouseEvent) {
 }
 onMounted(() => {
     window.addEventListener('keydown', handleKeyDown);
-    document.addEventListener('click', handleClickOutside); 
+    document.addEventListener('click', handleClickOutside);
 });
 
 onUnmounted(() => {
     window.removeEventListener('keydown', handleKeyDown);
-    document.removeEventListener('click', handleClickOutside); 
+    document.removeEventListener('click', handleClickOutside);
 });
 
 const canvasStore = useCanvasStore();
@@ -668,7 +668,7 @@ function thumbFillOpacity(shape: Shape): number {
 
     const opacity = (shape as unknown as Record<string, unknown>)
         .fillOpacity as number | undefined;
-    return typeof opacity === 'number' ? Math.max(0, Math.min(1,opacity)) : 1;
+    return typeof opacity === 'number' ? Math.max(0, Math.min(1, opacity)) : 1;
 }
 
 function thumbStroke(shape: Shape): string {

--- a/frontend/src/stores/canvas.ts
+++ b/frontend/src/stores/canvas.ts
@@ -280,18 +280,21 @@ export const useCanvasStore = defineStore('canvas', () => {
     }
 
     function setZoom(value: number) {
-        const newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, Math.round(value)));
+        const newZoom = Math.max(
+            MIN_ZOOM,
+            Math.min(MAX_ZOOM, Math.round(value))
+        );
         if (newZoom === zoom.value) return;
-        
+
         // Сохраняем мировую точку, которая сейчас в центре экрана
         const worldCenterX = -pan.value.x / (zoom.value / 100);
         const worldCenterY = -pan.value.y / (zoom.value / 100);
-        
+
         // Новый pan для того же центра
         const newZoomFactor = newZoom / 100;
         const newPanX = -worldCenterX * newZoomFactor;
         const newPanY = -worldCenterY * newZoomFactor;
-        
+
         zoom.value = newZoom;
         pan.value = { x: newPanX, y: newPanY };
     }
@@ -306,29 +309,37 @@ export const useCanvasStore = defineStore('canvas', () => {
 
     function zoomAtCenter(delta: number) {
         // Получаем размеры канваса из переданного референса или ищем по классу
-        const canvasEl = document.querySelector('.main-canvas') as HTMLCanvasElement | null;
+        const canvasEl = document.querySelector(
+            '.main-canvas'
+        ) as HTMLCanvasElement | null;
         const rect = canvasEl?.getBoundingClientRect();
-        
+
         if (!rect) {
             // Если канвас не найден, просто меняем зум без коррекции pan
-            zoom.value = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom.value + delta));
+            zoom.value = Math.max(
+                MIN_ZOOM,
+                Math.min(MAX_ZOOM, zoom.value + delta)
+            );
             return;
         }
-        
+
         // Какая мировая точка сейчас в центре экрана?
         // Используем ту же математику, что и в getLocalPoint
         const zoomFactor = zoom.value / 100;
         const worldCenterX = -pan.value.x / zoomFactor;
         const worldCenterY = -pan.value.y / zoomFactor;
-        
+
         // Новый зум
-        const newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom.value + delta));
+        const newZoom = Math.max(
+            MIN_ZOOM,
+            Math.min(MAX_ZOOM, zoom.value + delta)
+        );
         const newZoomFactor = newZoom / 100;
-        
+
         // Новый pan для того же центра
         const newPanX = -worldCenterX * newZoomFactor;
         const newPanY = -worldCenterY * newZoomFactor;
-        
+
         zoom.value = newZoom;
         pan.value = { x: newPanX, y: newPanY };
     }


### PR DESCRIPTION
Рамка выделения сбрасывается при переключении с инструмента "Курсор" на к.-л. другой
Предыдущие исправления и фичи (почему-то не зафиксировались):
Исправлена работа зума
При экспорте в png на изображение попадают все фигуры, а не только видимая часть холста
При создании фигур миниатюры в слоях не имеют цветную заливку

