### PR TITLE
Add arrow in menu(#122)

### DIFF
--- a/frontend/src/gui/components/EditorShell.vue
+++ b/frontend/src/gui/components/EditorShell.vue
@@ -9,11 +9,17 @@
                 <TopLeftActions />
             </div>
 
-            <div v-show="!isFocusMode" class="rightPanelWrap" :class="{ closed: !isInspectorOpen }">
+            <div
+                v-show="!isFocusMode"
+                class="rightPanelWrap"
+                :class="{ closed: !isInspectorOpen }"
+            >
                 <button
                     class="toggleInspectorBtn"
                     type="button"
-                    :title="isInspectorOpen ? 'Скрыть панель' : 'Показать панель'"
+                    :title="
+                        isInspectorOpen ? 'Скрыть панель' : 'Показать панель'
+                    "
                     @click="isInspectorOpen = !isInspectorOpen"
                 >
                     {{ isInspectorOpen ? '›' : '‹' }}


### PR DESCRIPTION
Добавлена стрелка с левой стороны меню, с помощью которой меню "прячется".
Также реализована горячая клавиша "Shift+Space", которая убирает всё лишнее, оставляя только рабочую зону. И она же используется, чтобы вернуть всё обратно.