### PR TITLE
fix: saving to the backend (#134)

### DIFF
--- a/frontend/src/stores/canvas.ts
+++ b/frontend/src/stores/canvas.ts
@@ -835,7 +835,7 @@ export const useCanvasStore = defineStore('canvas', () => {
             syncDocumentTimer = null;
             void syncDocument();
         }, SYNC_DOCUMENT_DEBOUNCE_MS);
-    }    
+    }
 
     function exportToJson(): string {
         const payload: VectorEditorExport = {


### PR DESCRIPTION
Closes issue #134

Реализована синхронизация документа с сервером (scheduleDocumentSync) и отдельный таймер для неё, чтобы изменения отправлялись автоматически без перезагрузки страницы и без спама запросами. 
Сейчас стоит в файле frontend\src\stores\canvas.ts:
 const SYNC_DOCUMENT_DEBOUNCE_MS = 400;
- после каждого изменения через 0.4 секунды происходит синхронизация с сервером (может быть слишком часто и стоит увеличить этот таймер, нужно потестить с серверной частью).

Добавлен явный вызов синхронизации после операций, где изменения часто происходят через мутации объектов фигур (перемещение, обновление, удаление, дублирование, undo/redo, импорт).