### PR TITLE
fix: added pencil support when exporting to svg

### DIFF
--- a/frontend/src/canvas/utils/export.ts
+++ b/frontend/src/canvas/utils/export.ts
@@ -290,6 +290,14 @@ function shapeToSvgElement(shape: Shape): string | null {
                 .join(' ');
             return `<polygon points="${pointsStr}"${transform}${style}/>`;
         }
+        case 'pencil': {
+            const points = s.points;
+            if (!points || points.length ===0) return null;
+            const pointsStr = points
+                .map((p: Point) => `${p.x},${p.y}`)
+                .join(' ');
+            return `<polyline points="${pointsStr}" fill="none"${transform}${style}/>`;
+        }
         default:
             return null;
     }

--- a/frontend/src/canvas/utils/export.ts
+++ b/frontend/src/canvas/utils/export.ts
@@ -292,7 +292,7 @@ function shapeToSvgElement(shape: Shape): string | null {
         }
         case 'pencil': {
             const points = s.points;
-            if (!points || points.length ===0) return null;
+            if (!points || points.length === 0) return null;
             const pointsStr = points
                 .map((p: Point) => `${p.x},${p.y}`)
                 .join(' ');


### PR DESCRIPTION
Close #152 
Добавлен карандаш при экспорте в svg. Экспорт текущего фона уже был реализован.