### PR TITLE
feat: #133: add trapezoid shape tool

### DIFF
--- a/frontend/src/canvas/composables/useCanvasRender.ts
+++ b/frontend/src/canvas/composables/useCanvasRender.ts
@@ -148,7 +148,10 @@ export function useCanvasRender(
                 ctx.strokeStyle = '#ff9800';
                 ctx.lineWidth = 1.5;
 
-                for (const [vx, vy] of [[tlX, topY], [trX, topY]] as [number, number][]) {
+                for (const [vx, vy] of [
+                    [tlX, topY],
+                    [trX, topY],
+                ] as [number, number][]) {
                     ctx.beginPath();
                     ctx.arc(vx, vy, 5, 0, Math.PI * 2);
                     ctx.fill();

--- a/frontend/src/canvas/composables/useCanvasRender.ts
+++ b/frontend/src/canvas/composables/useCanvasRender.ts
@@ -2,6 +2,7 @@ import type { Ref } from 'vue';
 import type { Shape, LineShape } from '@/canvas/types';
 import { SELECTION_PADDING } from '@/canvas/types';
 import { useCanvasStore } from '@/stores/canvas';
+import type { TrapezoidShape } from '@/canvas/types/trapezoid/trapezoid';
 
 function isLineShape(shape: Shape): shape is LineShape {
     return shape.type === 'line';
@@ -134,6 +135,26 @@ export function useCanvasRender(
                 ctx.fill();
                 ctx.stroke();
             });
+
+            if (shape.type === 'trapezoid') {
+                const trap = shape as TrapezoidShape;
+                const halfH = trap.height / 2;
+                const tlX = trap.topLeftX * trap.scaleX;
+                const trX = trap.topRightX * trap.scaleX;
+                const topY = -halfH * trap.scaleY;
+
+                ctx.setLineDash([0, 0]);
+                ctx.fillStyle = '#ffffff';
+                ctx.strokeStyle = '#ff9800';
+                ctx.lineWidth = 1.5;
+
+                for (const [vx, vy] of [[tlX, topY], [trX, topY]] as [number, number][]) {
+                    ctx.beginPath();
+                    ctx.arc(vx, vy, 5, 0, Math.PI * 2);
+                    ctx.fill();
+                    ctx.stroke();
+                }
+            }
 
             return;
         }

--- a/frontend/src/canvas/composables/useInteractions.ts
+++ b/frontend/src/canvas/composables/useInteractions.ts
@@ -9,6 +9,7 @@ import type {
 import { useCanvasStore } from '@/stores/canvas';
 import { useToolsStore, type ToolType } from '@/stores/tools';
 import { SELECTION_PADDING } from '@/canvas/types';
+import type { TrapezoidShape } from '@/canvas/types/trapezoid/trapezoid';
 
 type ResizeHandle =
     | 'l'
@@ -21,7 +22,9 @@ type ResizeHandle =
     | 'rb'
     | 's'
     | 'e'
-    | 'rot';
+    | 'rot'
+    | 'tlv'
+    | 'trv';
 
 interface ShapeResizeState {
     shape: Shape;
@@ -196,6 +199,23 @@ export function useInteractions(
         const cornerRadius = 8 * zoomCoef;
         const edgeRadius = 4 * zoomCoef;
 
+        if (shape.type === 'trapezoid') {
+            const trap = shape as TrapezoidShape;
+            const vInv = trap.getInverseVMatrix();
+            const vPt = new DOMPoint(
+                globalPoint.x,
+                globalPoint.y
+            ).matrixTransform(vInv);
+
+            const halfH = trap.height / 2;
+            const tlX = trap.topLeftX * Math.abs(trap.scaleX);
+            const trX = trap.topRightX * Math.abs(trap.scaleX);
+            const topY = -halfH * Math.abs(trap.scaleY);
+
+            if (Math.hypot(vPt.x - tlX, vPt.y - topY) <= 8) return 'tlv';
+            if (Math.hypot(vPt.x - trX, vPt.y - topY) <= 8) return 'trv';
+        }
+
         if (shape.type === 'line') {
             const line = shape as LineShape;
             if (!line.localEndPoint) return null;
@@ -317,6 +337,7 @@ export function useInteractions(
 
     function getCursorStyle(handle: string, shape: Shape): string {
         if (handle === 's' || handle === 'e') return 'crosshair';
+        if (handle === 'tlv' || handle === 'trv') return 'ew-resize';
         if (handle === 'rot') return 'grabbing';
 
         const handleAngles: Partial<Record<ResizeHandle, number>> = {
@@ -538,6 +559,7 @@ export function useInteractions(
             'star',
             'hexagon',
             'arrow',
+            'trapezoid',
         ];
 
         if (creatingTools.includes(toolsStore.activeTool)) {
@@ -1105,6 +1127,28 @@ export function useInteractions(
             const localMouse = new DOMPoint(point.x, point.y).matrixTransform(
                 mInv
             );
+
+            if (
+                activeShape.value.type === 'trapezoid' &&
+                (handle === 'tlv' || handle === 'trv')
+            ) {
+                if (!hasRecordedInteraction.value) {
+                    canvasStore.startInteraction();
+                    hasRecordedInteraction.value = true;
+                }
+                const trap = activeShape.value as TrapezoidShape;
+                const localMouse = new DOMPoint(
+                    point.x,
+                    point.y
+                ).matrixTransform(mInv);
+                if (handle === 'tlv') {
+                    trap.topLeftX = localMouse.x;
+                } else {
+                    trap.topRightX = localMouse.x;
+                }
+                canvas.style.cursor = 'ew-resize';
+                return;
+            }
 
             if (
                 activeShape.value.type === 'line' &&

--- a/frontend/src/canvas/types/index.ts
+++ b/frontend/src/canvas/types/index.ts
@@ -10,6 +10,7 @@ export { ArrowShape } from './arrow';
 export { HexagonShape } from './hexagon';
 export { ParallelogramShape } from './parallelogram';
 export { PencilShape } from './pencil';
+export { TrapezoidShape } from './trapezoid';
 export { shapeRegistry } from './registry';
 export { SELECTION_PADDING } from './base';
 

--- a/frontend/src/canvas/types/trapezoid/index.ts
+++ b/frontend/src/canvas/types/trapezoid/index.ts
@@ -1,0 +1,1 @@
+export { TrapezoidShape } from './trapezoid';

--- a/frontend/src/canvas/types/trapezoid/trapezoid.ts
+++ b/frontend/src/canvas/types/trapezoid/trapezoid.ts
@@ -1,0 +1,241 @@
+import { Editable } from '../property';
+import type { BoundingBox, Point } from '../base';
+import { BaseShape } from '../base';
+import { shapeRegistry } from '../registry';
+
+export class TrapezoidShape extends BaseShape {
+    type = 'trapezoid';
+
+    @Editable({ label: 'Позиция X', type: 'number' })
+    get x(): number {
+        return this.position.x;
+    }
+    set x(value: number) {
+        this.move({ x: value - this.position.x, y: 0 });
+    }
+
+    @Editable({ label: 'Позиция Y', type: 'number' })
+    get y(): number {
+        return this.position.y;
+    }
+    set y(value: number) {
+        this.move({ x: 0, y: value - this.position.y });
+    }
+
+    @Editable({ label: 'Ширина (основание)', type: 'number', min: 1 })
+    width: number;
+
+    @Editable({ label: 'Высота', type: 'number', min: 1 })
+    height: number;
+
+    @Editable({ label: 'Смещение левой вершины', type: 'number' })
+    topLeftX: number;
+
+    @Editable({ label: 'Смещение правой вершины', type: 'number' })
+    topRightX: number;
+
+    @Editable({ label: 'Поворот', type: 'number', min: 0, max: 360, step: 1 })
+    rotation: number;
+
+    @Editable({ label: 'Цвет заливки', type: 'color' })
+    fill: string;
+
+    @Editable({
+        label: 'Прозрачность заливки',
+        type: 'number',
+        min: 0,
+        max: 1,
+        step: 0.1,
+    })
+    fillOpacity: number;
+
+    @Editable({ label: 'Цвет контура', type: 'color' })
+    stroke: string;
+
+    @Editable({
+        label: 'Прозрачность контура',
+        type: 'number',
+        min: 0,
+        max: 1,
+        step: 0.1,
+    })
+    strokeOpacity: number;
+
+    @Editable({
+        label: 'Толщина контура',
+        type: 'number',
+        min: 0.5,
+        max: 20,
+        step: 0.5,
+    })
+    strokeWidth: number;
+
+    constructor(
+        id: string,
+        position: Point,
+        width: number = 120,
+        height: number = 80,
+        topLeftX: number = -30,
+        topRightX: number = 30,
+        rotation: number = 0,
+        fill: string = '#3498db',
+        fillOpacity: number = 0,
+        stroke: string = '#2c3e50',
+        strokeOpacity: number = 1,
+        strokeWidth: number = 2
+    ) {
+        super(id, position);
+        this.width = width;
+        this.height = height;
+        this.topLeftX = topLeftX;
+        this.topRightX = topRightX;
+        this.rotation = rotation;
+        this.fill = fill;
+        this.fillOpacity = fillOpacity;
+        this.stroke = stroke;
+        this.strokeOpacity = strokeOpacity;
+        this.strokeWidth = strokeWidth;
+    }
+
+    setSize(width: number, height: number): void {
+        if (this.width > 0) {
+            const ratio = width / this.width;
+            this.topLeftX = this.topLeftX * ratio;
+            this.topRightX = this.topRightX * ratio;
+        } else {
+            this.topLeftX = -width / 4;
+            this.topRightX = width / 4;
+        }
+        this.width = width;
+        this.height = height;
+    }
+
+    private getVertices(): Point[] {
+        const rotationRad = (this.rotation * Math.PI) / 180;
+        const cos = Math.cos(rotationRad);
+        const sin = Math.sin(rotationRad);
+        const halfW = this.width / 2;
+        const halfH = this.height / 2;
+
+        const localPoints = [
+            { x: -halfW * this.scaleX, y: halfH * this.scaleY },
+            { x: halfW * this.scaleX, y: halfH * this.scaleY },
+            { x: this.topRightX * this.scaleX, y: -halfH * this.scaleY },
+            { x: this.topLeftX * this.scaleX, y: -halfH * this.scaleY },
+        ];
+
+        return localPoints.map((p) => ({
+            x: this.position.x + p.x * cos - p.y * sin,
+            y: this.position.y + p.x * sin + p.y * cos,
+        }));
+    }
+
+    getLocalPoints(): Point[] {
+        const halfW = this.width / 2;
+        const halfH = this.height / 2;
+        return [
+            { x: -halfW, y: halfH },
+            { x: halfW, y: halfH },
+            { x: this.topRightX, y: -halfH },
+            { x: this.topLeftX, y: -halfH },
+        ];
+    }
+
+    hitTest(point: Point): boolean {
+        const vertices = this.getVertices();
+        const n = vertices.length;
+
+        let inside = false;
+        for (let i = 0, j = n - 1; i < n; j = i++) {
+            const xi = vertices[i]!.x,
+                yi = vertices[i]!.y;
+            const xj = vertices[j]!.x,
+                yj = vertices[j]!.y;
+            if (
+                yi > point.y !== yj > point.y &&
+                point.x < ((xj - xi) * (point.y - yi)) / (yj - yi) + xi
+            ) {
+                inside = !inside;
+            }
+        }
+        if (inside) return true;
+
+        const padding = this.strokeWidth / 2 + 3;
+        for (let i = 0, j = n - 1; i < n; j = i++) {
+            if (this.distanceToSegment(point, vertices[j]!, vertices[i]!) <= padding)
+                return true;
+        }
+        return false;
+    }
+
+    private distanceToSegment(p: Point, a: Point, b: Point): number {
+        const ab = { x: b.x - a.x, y: b.y - a.y };
+        const ap = { x: p.x - a.x, y: p.y - a.y };
+        const lenSq = ab.x * ab.x + ab.y * ab.y;
+        if (lenSq === 0) return Math.hypot(p.x - a.x, p.y - a.y);
+        const t = Math.max(0, Math.min(1, (ab.x * ap.x + ab.y * ap.y) / lenSq));
+        return Math.hypot(p.x - (a.x + t * ab.x), p.y - (a.y + t * ab.y));
+    }
+
+    getBoundingBox(): BoundingBox {
+        const vertices = this.getVertices();
+        let minX = Infinity,
+            minY = Infinity,
+            maxX = -Infinity,
+            maxY = -Infinity;
+        for (const v of vertices) {
+            minX = Math.min(minX, v.x);
+            minY = Math.min(minY, v.y);
+            maxX = Math.max(maxX, v.x);
+            maxY = Math.max(maxY, v.y);
+        }
+        const padding = this.strokeWidth / 2 + 5;
+        return {
+            minX: minX - padding,
+            minY: minY - padding,
+            maxX: maxX + padding,
+            maxY: maxY + padding,
+        };
+    }
+
+    getLocalBox(): BoundingBox {
+        const halfW = this.width / 2;
+        const halfH = this.height / 2;
+        return {
+            minX: Math.min(-halfW, this.topLeftX),
+            minY: -halfH,
+            maxX: Math.max(halfW, this.topRightX),
+            maxY: halfH,
+        };
+    }
+
+    render(ctx: CanvasRenderingContext2D): void {
+        const vertices = this.getVertices();
+        if (vertices.length < 4) return;
+
+        ctx.beginPath();
+        ctx.moveTo(vertices[0]!.x, vertices[0]!.y);
+        for (let i = 1; i < vertices.length; i++) {
+            ctx.lineTo(vertices[i]!.x, vertices[i]!.y);
+        }
+        ctx.closePath();
+
+        ctx.globalAlpha = this.fillOpacity;
+        ctx.fillStyle = this.fill;
+        ctx.fill();
+
+        ctx.globalAlpha = this.strokeOpacity;
+        ctx.strokeStyle = this.stroke;
+        ctx.lineWidth = this.strokeWidth;
+        ctx.stroke();
+
+        ctx.globalAlpha = 1;
+    }
+
+    move(delta: Point): void {
+        this.position.x += delta.x;
+        this.position.y += delta.y;
+    }
+}
+
+shapeRegistry.register('trapezoid', TrapezoidShape);

--- a/frontend/src/canvas/types/trapezoid/trapezoid.ts
+++ b/frontend/src/canvas/types/trapezoid/trapezoid.ts
@@ -162,7 +162,10 @@ export class TrapezoidShape extends BaseShape {
 
         const padding = this.strokeWidth / 2 + 3;
         for (let i = 0, j = n - 1; i < n; j = i++) {
-            if (this.distanceToSegment(point, vertices[j]!, vertices[i]!) <= padding)
+            if (
+                this.distanceToSegment(point, vertices[j]!, vertices[i]!) <=
+                padding
+            )
                 return true;
         }
         return false;

--- a/frontend/src/canvas/utils/export.ts
+++ b/frontend/src/canvas/utils/export.ts
@@ -290,6 +290,15 @@ function shapeToSvgElement(shape: Shape): string | null {
                 .join(' ');
             return `<polygon points="${pointsStr}"${transform}${style}/>`;
         }
+        case 'trapezoid': {
+            if (!s.getLocalPoints) return null;
+            const points = s.getLocalPoints();
+            if (!points || points.length === 0) return null;
+            const pointsStr = points
+                .map((p: Point) => `${p.x},${p.y}`)
+                .join(' ');
+            return `<polygon points="${pointsStr}"${transform}${style}/>`;
+        }
         case 'pencil': {
             const points = s.points;
             if (!points || points.length === 0) return null;

--- a/frontend/src/gui/components/BottomToolbar.vue
+++ b/frontend/src/gui/components/BottomToolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, watch, ref } from 'vue';
+import { computed, nextTick, watch, ref, h } from 'vue';
 import type { Component } from 'vue';
 import {
     Hand,
@@ -17,6 +17,26 @@ import {
     CopyPlus,
     Diamond,
 } from 'lucide-vue-next';
+const TrapezoidIcon: Component = {
+    render() {
+        return h(
+            'svg',
+            {
+                xmlns: 'http://www.w3.org/2000/svg',
+                width: 18,
+                height: 18,
+                viewBox: '0 0 24 24',
+                fill: 'none',
+                stroke: 'currentColor',
+                'stroke-width': 2,
+                'stroke-linecap': 'round',
+                'stroke-linejoin': 'round',
+            },
+            [h('polygon', { points: '5,18 19,18 16,6 8,6' })]
+        );
+    },
+};
+
 import { useToolsStore, type ToolType } from '@/stores/tools';
 import { useCanvasStore } from '@/stores/canvas';
 import { storeToRefs } from 'pinia';
@@ -33,6 +53,7 @@ type ToolId =
     | 'hexagon'
     | 'parallelogram'
     | 'arrow'
+    | 'trapezoid'
     | 'eraser'
     | 'pencil';
 
@@ -54,6 +75,7 @@ const tools: Tool[] = [
     { id: 'hexagon', title: 'Шестиугольник', icon: Hexagon },
     { id: 'parallelogram', title: 'Параллелограмм', icon: Diamond },
     { id: 'arrow', title: 'Стрелка', icon: ArrowUp },
+    { id: 'trapezoid', title: 'Трапеция', icon: TrapezoidIcon },
     { id: 'eraser', title: 'Ластик', icon: Eraser },
     { id: 'pencil', title: 'Карандаш', icon: Pencil },
 ];
@@ -133,6 +155,9 @@ function handleClick(tool: Tool) {
         case 'arrow':
             toolsStore.setActiveTool('arrow');
             break;
+        case 'trapezoid':
+            toolsStore.setActiveTool('trapezoid');
+            break;
         case 'eraser':
             toolsStore.setActiveTool('eraser');
             break;
@@ -179,6 +204,7 @@ const activeId = computed<ToolId>(() => {
     if (active === 'hexagon') return 'hexagon';
     if (active === 'parallelogram') return 'parallelogram';
     if (active === 'arrow') return 'arrow';
+    if (active === 'trapezoid') return 'trapezoid';
     if (active === 'eraser') return 'eraser';
     if (active === 'pencil') return 'pencil';
     return 'cursor';

--- a/frontend/src/gui/components/EditorToolbar.vue
+++ b/frontend/src/gui/components/EditorToolbar.vue
@@ -80,6 +80,12 @@ const tools: ToolConfig[] = [
         title: 'Стрелка',
         action: () => toolsStore.setActiveTool('arrow'),
     },
+    {
+        id: 'trapezoid',
+        icon: '⏢',
+        title: 'Трапеция',
+        action: () => toolsStore.setActiveTool('trapezoid'),
+    },
 ];
 
 function handleToolClick(tool: ToolConfig) {

--- a/frontend/src/stores/canvas.ts
+++ b/frontend/src/stores/canvas.ts
@@ -485,7 +485,9 @@ export const useCanvasStore = defineStore('canvas', () => {
                                 ? 'Параллелограмм'
                                 : type === 'pencil'
                                   ? 'Карандаш'
-                                  : type;
+                                  : type === 'trapezoid'
+                                    ? 'Трапеция'
+                                    : type;
 
         const number = existingShapesOfType.length + 1;
         const defaultName = `${typeName} ${number}`;

--- a/frontend/src/stores/tools.ts
+++ b/frontend/src/stores/tools.ts
@@ -14,7 +14,8 @@ export type ToolType =
     | 'parallelogram'
     | 'arrow'
     | 'eraser'
-    | 'pencil';
+    | 'pencil'
+    | 'trapezoid';
 
 type CreationParams = Record<string, unknown> | null;
 


### PR DESCRIPTION
- Add TrapezoidShape class with topLeftX/topRightX vertex parameters
- Register trapezoid in shape registry, tools store and canvas store
- Add custom tlv/trv drag handles for asymmetric top-vertex editing
- Render orange vertex handles in canvas
- Add trapezoid button to BottomToolbar and EditorToolbar
- Add SVG export support for trapezoid shape